### PR TITLE
fix: build for twister

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ DEFAULT_APP_DIR ?= app
 APP_DIR ?= $(DEFAULT_APP_DIR)
 APP_DOMAIN ?= $(APP_DIR)
 
+# Test directory
+TEST_DIR ?= $(APP_DIR)/tests
+
 # West build directories
 APP_BUILD_DIR ?= build
 
@@ -50,7 +53,7 @@ combined:
 
 .PHONY: test
 test:
-	$(Q)west twister -T $(APP_DIR) --platform $(BOARD)
+	$(Q)west twister -T $(TEST_DIR) --platform $(BOARD)
 
 .PHONY: flash-app
 flash-app: app
@@ -79,6 +82,7 @@ help:
 	@echo "  VERBOSE: Show verbose output (0 or 1, default 0)"
 	@echo "  BOARD: Target board (default: $(DEFAULT_BOARD))"
 	@echo "  APP_DIR: Application directory (default: ${APP_DIR})"
+	@ech "   TEST_DIR: Test directory (default: ${TEST_DIR})"
 	@echo "Targets:"
 	@echo "  all: Build both application and bootloader"
 	@echo "  app: Build application"

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ This project is ideal for developers working with Zephyr RTOS, especially those 
 
 The project is functional. It has been tested on the `nucleo_wb55rg` board and is ready for use in developing Zephyr applications with MCUboot support. The project is actively maintained, and contributions are welcome.
 
-Limitations:
-- Twister functionality is not fully implemented.
-
 **[Back to top](#table-of-contents)**
 
 ## Getting Started

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1749668643,
+        "narHash": "sha256-gaWJEWGBW/g1u6o5IM4Un0vluv86cigLuBnjsKILffc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "1965fd20a39c8e441746bee66d550af78f0c0a7b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     {
         devShells.${system}.default = pkgs.mkShell {
             name = "zephyr-dev";
-            buildInputs = with pkgs; [
+            packages = with pkgs; [
                 cmake
                 ninja
                 gperf


### PR DESCRIPTION
# Description

building integration tests with `west twister` failed to build

Fixes # (issue)

```sh
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libdl.so when searching for -ldl
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libdl.so when searching for -ldl
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: cannot find -ldl: No such file or directory
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libdl.so when searching for -ldl
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libdl.so when searching for -ldl
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libm.so when searching for -lm
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libm.so when searching for -lm
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: cannot find -lm: No such file or directory
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libm.so when searching for -lm
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/5m9amsvvh2z8sl7jrnc87hzy21glw6k1-glibc-2.40-66/lib/libm.so when searching for -lm
/nix/store/36cxz4bnx0cdyy7q9abr34p26qw0rbn7-binutils-2.43.1/bin/ld: skipping incompatible /nix/store/hx59pzhi1x2mfm1yjyg8rf3c9swa4nph-gcc-13.3.0/lib/gcc/x86_64-unknown-linux-gnu/13.3.0/libgcc.a when searching for -lgcc
```

# How Has This Been Tested?
- [x] Manual testing  `west twister -W -p native_sim -T tests/integration/`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
